### PR TITLE
Fix CD workflow with release artifact upload

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,7 +108,9 @@ jobs:
     needs: [build]
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
-    environment: test-pypi
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/clusx
 
     permissions:
       id-token: write
@@ -135,7 +137,9 @@ jobs:
     needs: [build]
 
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    environment: production-pypi
+    environment:
+      name: production-pypi
+      url: https://pypi.org/p/clusx
 
     permissions:
       id-token: write
@@ -153,6 +157,36 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
+
+  upload_release_artifacts:
+    name: Upload release artifacts
+    runs-on: ubuntu-latest
+
+    needs: [build, upload_pypi]
+
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    environment:
+      name: github-releases
+      url: https://github.com/sergeyklay/clusterium/releases
+
+    permissions:
+      contents: write
+      checks: write
+
+      actions: read
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+          merge-multiple: true
 
       - name: Generate checksums
         run: |


### PR DESCRIPTION
- Add environment URLs for test and production PyPI deployments
- Implement new job to upload release artifacts to GitHub Releases
- Include artifact download and checksum generation steps