### PR TITLE
Improve cascading metadata resolution in version module

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Improved Documentation
 
 * Amend project documentation.
 
+Trivial/Internal Changes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Improve cascading metadata resolution in :mod:`clusx.version` module.
+
 0.3.3 - 2025-03-12
 ------------------
 

--- a/clusx/version.py
+++ b/clusx/version.py
@@ -13,11 +13,11 @@ import importlib.metadata
 import importlib.util
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 
 @lru_cache(maxsize=1)
-def get_metadata() -> Dict[str, str]:
+def get_metadata() -> dict[str, str]:
     """Retrieve package metadata using a cascading resolution strategy."""
     resolvers = [
         _get_installed_metadata,
@@ -31,7 +31,7 @@ def get_metadata() -> Dict[str, str]:
     return _get_fallback_metadata()
 
 
-def _get_installed_metadata() -> Optional[Dict[str, str]]:
+def _get_installed_metadata() -> Optional[dict[str, str]]:
     """Get metadata from installed package."""
     try:
         pkg_meta = importlib.metadata.metadata("clusx")
@@ -47,7 +47,7 @@ def _get_installed_metadata() -> Optional[Dict[str, str]]:
         return None
 
 
-def _get_pyproject_metadata() -> Optional[Dict[str, str]]:
+def _get_pyproject_metadata() -> Optional[dict[str, str]]:
     """Get metadata from pyproject.toml."""
     pyproject_data = _find_and_parse_pyproject()
     if not pyproject_data:
@@ -69,7 +69,7 @@ def _get_pyproject_metadata() -> Optional[Dict[str, str]]:
     }
 
 
-def _get_fallback_metadata() -> Dict[str, str]:
+def _get_fallback_metadata() -> dict[str, str]:
     """Get fallback metadata values."""
     return {
         "version": "0.0.0+dev",
@@ -81,7 +81,7 @@ def _get_fallback_metadata() -> Dict[str, str]:
     }
 
 
-def _find_and_parse_pyproject() -> Optional[Dict[str, Any]]:
+def _find_and_parse_pyproject() -> Optional[dict[str, Any]]:
     """Find and parse pyproject.toml file."""
     # Traverse up from current directory to find pyproject.toml
     current_dir = Path(__file__).parent
@@ -98,7 +98,7 @@ def _find_and_parse_pyproject() -> Optional[Dict[str, Any]]:
     return None
 
 
-def _parse_toml(path: Path) -> Optional[Dict[str, Any]]:
+def _parse_toml(path: Path) -> Optional[dict[str, Any]]:
     """Parse TOML file with appropriate parser."""
     # Try stdlib tomllib (Python 3.11+) first, then fallback to tomli
     for module_name in ("tomllib", "tomli"):

--- a/clusx/version.py
+++ b/clusx/version.py
@@ -22,14 +22,13 @@ def get_metadata() -> Dict[str, str]:
     resolvers = [
         _get_installed_metadata,
         _get_pyproject_metadata,
-        _get_fallback_metadata,
     ]
 
     for resolver in resolvers:
         if metadata := resolver():
             return metadata
 
-    return _get_fallback_metadata()  # Should never reach here, but just in case
+    return _get_fallback_metadata()
 
 
 def _get_installed_metadata() -> Optional[Dict[str, str]]:
@@ -37,12 +36,12 @@ def _get_installed_metadata() -> Optional[Dict[str, str]]:
     try:
         pkg_meta = importlib.metadata.metadata("clusx")
         return {
-            "version": pkg_meta["Version"],
-            "description": pkg_meta["Summary"],
-            "license": pkg_meta["License"],
-            "author": pkg_meta["Author"],
-            "author_email": pkg_meta["Author-email"],
-            "url": pkg_meta["Home-page"],
+            "version": pkg_meta.get("Version", "0.0.0+dev"),
+            "description": pkg_meta.get("Summary", "Clusterium"),
+            "license": pkg_meta.get("License", "MIT"),
+            "author": pkg_meta.get("Author", "Serghei Iakovlev"),
+            "author_email": pkg_meta.get("Author-email", "oss@serghei.pl"),
+            "url": pkg_meta.get("Home-page", "https://clusterium.readthedocs.io"),
         }
     except (importlib.metadata.PackageNotFoundError, KeyError):
         return None
@@ -57,6 +56,7 @@ def _get_pyproject_metadata() -> Optional[Dict[str, str]]:
     project = pyproject_data.get("project", {})
     poetry = pyproject_data.get("tool", {}).get("poetry", {})
     authors = project.get("authors", [])
+    urls = project.get("urls", {})
     author_info = authors[0] if authors else {}
 
     return {
@@ -65,9 +65,7 @@ def _get_pyproject_metadata() -> Optional[Dict[str, str]]:
         "license": project.get("license", "MIT"),
         "author": author_info.get("name", "Serghei Iakovlev"),
         "author_email": author_info.get("email", "oss@serghei.pl"),
-        "url": project.get("urls", {}).get(
-            "homepage", "https://clusterium.readthedocs.io"
-        ),
+        "url": urls.get("homepage", "https://clusterium.readthedocs.io"),
     }
 
 


### PR DESCRIPTION
- Improve cascading metadata resolution by refining the order of resolvers.
- Update fallback metadata retrieval to ensure defaults are provided.
- Adjust metadata extraction to use safer get methods for better error handling.